### PR TITLE
Fix two GraphQL selections that Linear's schema no longer accepts

### DIFF
--- a/src/commands/initiatives.rs
+++ b/src/commands/initiatives.rs
@@ -393,4 +393,3 @@ async fn delete_initiative(id: &str, force: bool) -> Result<()> {
 
     Ok(())
 }
-

--- a/src/commands/initiatives.rs
+++ b/src/commands/initiatives.rs
@@ -66,8 +66,8 @@ struct InitiativeRow {
     name: String,
     #[tabled(rename = "Status")]
     status: String,
-    #[tabled(rename = "Progress")]
-    progress: String,
+    #[tabled(rename = "Health")]
+    health: String,
     #[tabled(rename = "Projects")]
     project_count: String,
 }
@@ -113,7 +113,7 @@ async fn list_initiatives(output: &OutputOptions, pagination: &PaginationOptions
                     description
                     status
                     sortOrder
-                    progress
+                    health
                     projects {
                         nodes {
                             id
@@ -143,10 +143,7 @@ async fn list_initiatives(output: &OutputOptions, pagination: &PaginationOptions
             .iter()
             .filter_map(|v| {
                 let i = serde_json::from_value::<Initiative>(v.clone()).ok()?;
-                let progress = format!(
-                    "{}%",
-                    (v["progress"].as_f64().unwrap_or(0.0) * 100.0) as i32
-                );
+                let health = v["health"].as_str().unwrap_or("-").to_string();
                 let project_count = v["projects"]["nodes"]
                     .as_array()
                     .map(|a| a.len().to_string())
@@ -155,7 +152,7 @@ async fn list_initiatives(output: &OutputOptions, pagination: &PaginationOptions
                     id: i.id,
                     name: truncate(&i.name, max_width),
                     status: i.status.as_deref().unwrap_or("-").to_string(),
-                    progress,
+                    health,
                     project_count,
                 })
             })

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -1031,8 +1031,6 @@ async fn get_issue(id: &str, output: &OutputOptions, history: bool, comments: bo
                         toProject { name }
                         archived
                         trashed
-                        slaBreachesAt
-                        slaStartedAt
                     }
                 }"#
     } else {


### PR DESCRIPTION
Two commands return HTTP 400 for every caller against the current Linear schema. Both are one-field fixes.

### `initiatives list`

```
$ linear-cli initiatives list -o json --compact
Cannot query field "progress" on type "Initiative". Did you mean "projects"?
```

Introspecting the live schema, `Initiative` has 49 fields and `progress` is not among them — it carries `health` and `status` instead. Linear appears to have removed it. This selects `health` and shows it in the table where the derived percentage used to go.

Deliberately left alone:
- `initiative get` never selected the field, so it was never broken.
- The `progress` selection on `Project`, inside the initiative's projects query, is still valid — `Project` does expose `progress`.

### `issues get --history`

```
$ linear-cli issues get ENG-843 --history -o json --compact --fields identifier
Cannot query field "slaBreachesAt" on type "IssueHistory".
Did you mean "toSlaBreachesAt", "fromSlaBreachesAt", or "toSlaBreached"?
```

`IssueHistory` only carries the `to*`/`from*` prefixed variants. This drops the two bare selections from the history fragment. The identically named fields on the `Issue` type are valid and stay, as does the formatter that reads them.

This is the same class of bug as #29, which you fixed in 0.3.26.

### Also included

A one-line `chore` commit removing a trailing blank line from `initiatives.rs`. It is the only formatting diff in the tree, and PR Check has been failing on "Check formatting" since 2026-08-05 because of it — so without it this PR shows red through no fault of its own. Happy to split it out if you would rather take it separately.

### Verification

Run against a live workspace on macOS arm64, and all three commands now return data:

```
cargo fmt --check                                        # clean
cargo clippy --release --features secure-storage -- -D warnings   # clean
cargo test --release --features secure-storage           # 352 passed, 203 passed
```

### Context

We drive linear-cli from an agent harness, and these two accounted for 78 failed invocations in a single week — they are the top two failure modes in our logs. Thanks for the tool.