### PR TITLE
Fix the release workflow so a dispatch actually produces assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ name: Release
 # Blacksmith free tier is not consumed by surprise release builds. The
 # workflow stays local-by-default: an operator dispatches it after a manual
 # `cargo publish`. See docs/adr/0001-pr-check-blacksmith-local-release.md.
+#
+# The release matrix runs on GitHub-hosted runners. This repository is public,
+# so those minutes are free, and a rare dispatch-only release then costs the
+# shared Blacksmith pool nothing at all — which is what ADR 0001 set out to
+# protect. PR Check stays on Blacksmith, unchanged.
 
 on:
   workflow_dispatch:
@@ -35,7 +40,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-pc-windows-msvc
-            runner: blacksmith-4vcpu-windows-2025
+            runner: windows-latest
             ext: .exe
           - target: x86_64-apple-darwin
             runner: macos-latest
@@ -44,10 +49,10 @@ jobs:
             runner: macos-latest
             ext: ""
           - target: x86_64-unknown-linux-gnu
-            runner: blacksmith-4vcpu-ubuntu-2404
+            runner: ubuntu-latest
             ext: ""
           - target: aarch64-unknown-linux-gnu
-            runner: blacksmith-4vcpu-ubuntu-2404
+            runner: ubuntu-latest
             ext: ""
             use_cross: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and attach assets to (e.g. v0.3.28)"
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -48,6 +53,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Install Linux keyring build deps
         if: runner.os == 'Linux' && !matrix.use_cross
@@ -112,6 +119,9 @@ jobs:
       - name: Upload to release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
+          # Without an explicit tag the action falls back to github.ref, which
+          # is a branch ref whenever the workflow is dispatched from a branch.
+          tag_name: ${{ inputs.tag }}
           files: |
             linear-cli-*/linear-cli-*
 
@@ -125,6 +135,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.tag }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
     permissions:
       contents: read
     strategy:
+      # One unavailable runner must not cancel the legs that are healthy.
+      # In the v0.3.26 run, two legs failed to acquire a runner before any
+      # step executed, fail-fast cancelled the three healthy legs, and the
+      # release shipped with no assets at all.
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-pc-windows-msvc
@@ -87,13 +92,22 @@ jobs:
     name: Upload Release Assets
     needs: build
     runs-on: ubuntu-latest
-    if: vars.CI_BUDGET_MODE != 'off'
+    # Ship whatever built. A partial asset set beats the empty asset set that
+    # `needs: build` produced whenever any single target failed.
+    if: ${{ !cancelled() && vars.CI_BUDGET_MODE != 'off' }}
     permissions:
       contents: write
 
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+
+      - name: Verify at least one asset was built
+        run: |
+          count=$(find . -type f -name 'linear-cli-*' | wc -l | tr -d ' ')
+          echo "found $count asset(s)"
+          test "$count" -gt 0
+          find . -type f -name 'linear-cli-*' -exec ls -l {} +
 
       - name: Upload to release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2


### PR DESCRIPTION
Addresses #43. Every Release run since v0.3.7 has failed, which is why v0.3.26 shipped with no assets and v0.3.27 is Windows-only. There are three independent causes; each is its own commit so you can take them separately.

### 1. One failed leg cancels the rest

The v0.3.26 run:

| job | conclusion | steps executed |
|---|---|---|
| Build x86_64-pc-windows-msvc | failure | 0 |
| Build x86_64-unknown-linux-gnu | failure | 0 |
| Build aarch64-apple-darwin | **cancelled** | 0 |
| Build x86_64-apple-darwin | **cancelled** | 0 |
| Build aarch64-unknown-linux-gnu | **cancelled** | 0 |
| Upload Release Assets | skipped | — |

Zero steps on the failed jobs means they never acquired a runner. Default `fail-fast` then cancelled the three healthy legs, and `needs: build` skipped the upload — so a runner-availability problem on two targets became a release with nothing attached.

`fail-fast: false` makes an unavailable runner cost one target instead of five. `upload` now runs on `!cancelled()` so a partial asset set still reaches the release, with an explicit guard that fails loudly if nothing built rather than silently publishing an empty release.

### 2. The dispatched tag is never actually used

`workflow_dispatch` takes no inputs, so:

- the build matrix compiles whatever ref the dispatch happened to use;
- `softprops/action-gh-release` falls back to `github.ref` for the target release, which is a branch ref whenever the workflow is dispatched from a branch rather than a tag;
- the `publish` job checks out that same ref, so `cargo publish` can package the branch instead of the tagged source.

This adds a required `tag` input, checks it out in both the build matrix and the publish job, and passes it to the release action explicitly.

### 3. The release matrix cannot get Blacksmith runners

The Windows and Linux legs request Blacksmith runners and failed without executing a step. The label is live — PR Check uses `blacksmith-4vcpu-ubuntu-2404` successfully — but the release matrix requests three Blacksmith runners simultaneously and does not get them.

This moves the five release targets to GitHub-hosted runners. I want to be careful here because ADR 0001 is explicit about protecting the shared Blacksmith pool: this repository is public, so GitHub-hosted minutes are free, and a dispatch-only release that runs a few times a month then draws **nothing** from the shared pool. That serves the ADR's stated goal more completely than routing release builds through it. PR Check stays on Blacksmith, untouched.

If you would rather keep the release on Blacksmith, commits 1 and 2 stand on their own and are worth taking regardless — commit 1 alone would have given v0.3.26 its macOS assets.

### Verification

`actionlint` passes clean on the result. I have not been able to execute the workflow against your runners, so the runner change in commit 3 is the one piece verified by reasoning rather than by a run.