### PR TITLE
feat(issues): restore --project flag on issues create

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ linear-cli i get LIN-123 --comments              # Inline comments
 linear-cli i get LIN-1 LIN-2 LIN-3              # Batch fetch
 
 linear-cli i create "Fix login" -t ENG -p 1      # Create urgent issue
+linear-cli i create "Fix login" -t ENG --project "Q2 Roadmap"
 linear-cli i update LIN-123 -s Done              # Update status
 linear-cli i update LIN-123 -l bug -l urgent     # Add labels
 linear-cli i update LIN-123 --due tomorrow       # Set due date
@@ -99,6 +100,8 @@ linear-cli i archive LIN-123                     # Archive
 linear-cli i open LIN-123                        # Open in browser
 linear-cli i link LIN-123                        # Print URL
 ```
+
+**Create flags:** `--team`, `--description`, `--data`, `--priority`, `--state`, `--assignee`, `--labels`, `--due`, `--estimate`, `--project`, `--template`, `--dry-run`
 
 **List flags:** `--mine`, `--team`, `--state`, `--assignee`, `--project`, `--label`, `--since`, `--view`, `--group-by` (state/priority/assignee/project), `--count-only`, `--archived`
 

--- a/src/commands/issues.rs
+++ b/src/commands/issues.rs
@@ -103,6 +103,7 @@ pub enum IssueCommands {
     linear issues create "Fix bug" -t ENG      # Create with title and team
     linear i create "Feature" -t ENG -p 2      # Create with high priority
     linear i create "Task" -t ENG -a me        # Assign to yourself
+    linear i create "Task" -t ENG --project Q2 # Add to project
     linear i create "Task" -t ENG --due +3d    # Due in 3 days
     linear i create "Bug" -t ENG --dry-run     # Preview without creating"#)]
     Create {
@@ -135,6 +136,9 @@ pub enum IssueCommands {
         /// Estimate in points (e.g., 1, 2, 3, 5, 8)
         #[arg(short, long)]
         estimate: Option<f64>,
+        /// Project name or ID
+        #[arg(long)]
+        project: Option<String>,
         /// Template name to use for default values
         #[arg(long)]
         template: Option<String>,
@@ -348,6 +352,7 @@ pub async fn handle(
             labels,
             due,
             estimate,
+            project,
             template,
             dry_run,
         } => {
@@ -429,6 +434,7 @@ pub async fn handle(
                 final_labels,
                 due,
                 estimate,
+                project,
                 output,
                 agent_opts,
                 dry_run,
@@ -1267,6 +1273,7 @@ async fn create_issue(
     labels: Vec<String>,
     due: Option<String>,
     estimate: Option<f64>,
+    project: Option<String>,
     output: &OutputOptions,
     agent_opts: AgentOptions,
     dry_run: bool,
@@ -1356,6 +1363,14 @@ async fn create_issue(
     if let Some(e) = estimate {
         input["estimate"] = json!(e);
     }
+    if let Some(ref p) = project {
+        if dry_run {
+            input["projectId"] = json!(p);
+        } else {
+            let project_id = resolve_project_id(&client, p, &output.cache).await?;
+            input["projectId"] = json!(project_id);
+        }
+    }
 
     // Dry run: show what would be created without actually creating
     if dry_run {
@@ -1374,6 +1389,7 @@ async fn create_issue(
                         "labels": labels,
                         "dueDate": due,
                         "estimate": estimate,
+                        "project": project,
                     }
                 }),
                 output,
@@ -1408,6 +1424,9 @@ async fn create_issue(
             }
             if let Some(e) = estimate {
                 println!("  Estimate:    {}", e);
+            }
+            if let Some(ref p) = project {
+                println!("  Project:     {}", p);
             }
         }
         return Ok(());

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -74,6 +74,13 @@ fn test_issues_help() {
 }
 
 #[test]
+fn test_issues_create_help_includes_project() {
+    let (code, stdout, _stderr) = run_cli(&["issues", "create", "--help"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("--project"));
+}
+
+#[test]
 fn test_teams_help() {
     let (code, stdout, _stderr) = run_cli(&["teams", "--help"]);
     assert_eq!(code, 0);


### PR DESCRIPTION
Hi again, @Finesssee! 

We are using `linear-cli` quite a lot here (I'm on the same team as @oliviasculley) :) Here's a new proposed improvement from us:

------

`issues create` has no `--project` flag on `master`, so a new issue cannot be filed into a project in one call — you have to create it and then `issues move` it.

The flag was written in c7c7446 (`feat(issues): add project flag to create`, Jun 26). That commit lives on the `finesssee-add-project-flag` branch and was tagged `v0.3.27`, but no PR was ever opened and it never reached `master`. So it ships in the `v0.3.27` binary while being absent from the source everyone builds from.

This cherry-picks that commit onto current `master`, with original authorship preserved.

### What's in it

`--project <PROJECT>` on `issues create`, resolved via the existing `resolve_project_id` helper — the same resolver `issues update` and `issues move` already use, so name-or-ID handling and error messages match. Plus the README line and the test from the original commit.

Nothing else on `master` gains or loses behavior. `--project` already existed on `list`, `update`, and `move`; only `create` was missing it.

### Deliberately not included

- **The version bump.** The original commit bumped `0.3.26` -> `0.3.27`, but `v0.3.27` is already tagged against a different tree, so reusing it would be wrong and picking the next number is your release call. `Cargo.toml`/`Cargo.lock` are untouched here.
- **The `main.rs` `#[cfg(unix)]` test gating** from the original commit. `master` already fixed that independently, and more thoroughly. Dropped as redundant.

### Verification

macOS arm64:

```
cargo build --release          # clean
cargo test --release           # 347 passed, 204 passed
```

Two pre-existing issues in the tree that this PR does not touch and does not fix:

- `cargo fmt --check` flags a trailing blank line in `initiatives.rs:396` — the same one #46 offers to clean up.
- `cargo clippy --all-targets -D warnings` reports 4 `items_after_test_module` errors in `comments.rs`, `documents.rs`, `templates.rs`, `views.rs` on clippy 1.93. These look like toolchain drift against the 1.97 target in 474f71b rather than anything new.

Happy to rebase or drop the README/test hunks if you'd rather take it narrower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Issue creation now supports assigning an issue to a project by name or ID.
  - Dry-run output includes the selected project in both text and JSON formats.
  - Updated command examples and help text document the new project option.

- **Documentation**
  - Expanded README examples and option references for issue creation, including project and template flags.

- **Tests**
  - Added coverage confirming the project option appears in issue creation help.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->